### PR TITLE
prevent duplicate entries in bad words list

### DIFF
--- a/safetext/__init__.py
+++ b/safetext/__init__.py
@@ -273,7 +273,8 @@ class ProfanityChecker:
 
         bad_words = []
         for profanity in profanity_results:
-            bad_words.append(profanity["word"])
+            if profanity["word"] not in bad_words:
+                bad_words.append(profanity["word"])
 
         return bad_words
 

--- a/safetext/__init__.py
+++ b/safetext/__init__.py
@@ -7,7 +7,7 @@ import requests
 
 from safetext.utils import detect_language_from_srt, detect_language_from_text
 
-__version__ = "0.0.6"
+__version__ = "0.0.7"
 
 
 class SafeText:


### PR DESCRIPTION
The modification in the `get_bad_words` method adds a condition to ensure that each bad word is only added once to the `bad_words` list. This change prevents duplicate entries if the same bad word appears multiple times in the `profanity_results`. This enhancement maintains the integrity of the returned list, ensuring that each bad word is represented only once.
